### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joowankim @gringrape @DoLiLu @wenodev @DavidYang2149 @bbhye1 @dodoongtak


### PR DESCRIPTION
# Doing

- `.github/CODEOWNERS` 파일 추가

# Why

- PR 때 마다 수동으로 Reviewers를 등록하려면 매우 귀찮으실겁니다.
- 이게 자동으로 모두를 등록해줍니다.

# 참고사항

- 뺴먹거나 잘못 쓴 사람 있으면 말씀해주세요.